### PR TITLE
Add bilingual i18n support

### DIFF
--- a/VideoEnhancer-PC.vue
+++ b/VideoEnhancer-PC.vue
@@ -2,7 +2,7 @@
   <div class="video-enhancer-page">
     <!-- 侧边栏 -->
     <aside class="sidebar">
-      <div class="logo">MediaEnhance Pro</div>
+      <div class="logo">{{ translate('app.brand') }}</div>
       <nav class="nav-menu">
         <div
           v-for="(item, index) in menuItems"
@@ -11,15 +11,15 @@
           @click="handleMenuClick(index)"
         >
           <span class="nav-icon">{{ item.icon }}</span>
-          <span>{{ item.label }}</span>
+          <span>{{ translate(item.labelKey) }}</span>
         </div>
       </nav>
       <div class="user-info">
         <div class="nav-item user-account">
           <span class="nav-icon">👤</span>
           <div class="user-details">
-            <div class="user-name">User Account</div>
-            <div class="user-plan">Free Plan</div>
+            <div class="user-name">{{ translate('app.user.account') }}</div>
+            <div class="user-plan">{{ translate('app.user.plan') }}</div>
           </div>
         </div>
       </div>
@@ -30,9 +30,19 @@
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
-          <h1 class="header-title">Video & Image Enhancer</h1>
+          <div class="language-switcher">
+            <label :for="`${$options.name}-locale`" class="language-label">
+              {{ translate('language.label') }}
+            </label>
+            <select :id="`${$options.name}-locale`" v-model="locale" class="language-select">
+              <option v-for="code in availableLocales" :key="code" :value="code">
+                {{ translate(`language.options.${code}`) }}
+              </option>
+            </select>
+          </div>
+          <h1 class="header-title">{{ translate('videoEnhancer.header.title') }}</h1>
           <p class="header-subtitle">
-            Transform your low-quality videos and images into stunning high-resolution masterpieces using advanced AI technology.
+            {{ translate('videoEnhancer.header.subtitle') }}
           </p>
         </div>
 
@@ -42,7 +52,7 @@
           <div class="workspace-left">
             <!-- 上传区域 -->
             <div class="upload-container">
-              <h3 class="section-title">Upload Media</h3>
+              <h3 class="section-title">{{ translate('videoEnhancer.upload.title') }}</h3>
               <div
                 :class="['upload-area', { 'has-file': hasFile, 'dragover': isDragover }]"
                 @drop.prevent="handleDrop"
@@ -55,10 +65,10 @@
                 <!-- 上传内容 -->
                 <div v-if="!filePreview" class="upload-content">
                   <div class="upload-icon">⬆️</div>
-                  <div class="upload-title">Drop your files here</div>
-                  <div class="upload-subtitle">or click to browse</div>
+                  <div class="upload-title">{{ translate('videoEnhancer.upload.drop') }}</div>
+                  <div class="upload-subtitle">{{ translate('videoEnhancer.upload.browse') }}</div>
                   <el-button type="primary" size="small" class="upload-btn-small" @click.stop="triggerFileInput">
-                    Choose Files
+                    {{ translate('videoEnhancer.upload.button') }}
                   </el-button>
                   <input
                     ref="fileInput"
@@ -92,20 +102,20 @@
                 </div>
               </div>
               <div class="supported-formats">
-                Supported: .mp4, .mov, .m4v, .3gp, .avi, .jpg, .jpeg, .png (Max 8 files)
+                {{ translate('videoEnhancer.upload.supported') }}
               </div>
             </div>
 
             <!-- 示例文件 -->
             <div class="samples-container">
-              <h3 class="section-title">Quick Samples</h3>
+              <h3 class="section-title">{{ translate('videoEnhancer.samples.title') }}</h3>
               <div class="sample-grid">
                 <div
                   v-for="sample in samples"
                   :key="sample.type"
                   class="sample-item"
                   @click="loadSample(sample.type)"
-                  :title="sample.title"
+                  :title="translate(sample.titleKey)"
                 >
                   <span class="sample-icon">{{ sample.icon }}</span>
                 </div>
@@ -117,26 +127,26 @@
           <div class="workspace-right">
             <!-- 增强设置 -->
             <div class="settings-container">
-              <h3 class="section-title">Enhancement Settings</h3>
-              
+              <h3 class="section-title">{{ translate('videoEnhancer.settings.title') }}</h3>
+
               <!-- 分辨率选择 -->
               <div class="setting-group">
-                <div class="setting-label">Output Resolution</div>
+                <div class="setting-label">{{ translate('videoEnhancer.settings.resolution') }}</div>
                 <el-radio-group v-model="resolution" @change="handleSettingChange">
                   <div class="resolution-group">
                     <label class="radio-option">
                       <el-radio label="hd">
                         <div class="radio-content">
-                          <div class="radio-title">HD</div>
-                          <div class="radio-subtitle">1920×1080</div>
+                          <div class="radio-title">{{ translate('videoEnhancer.settings.hd') }}</div>
+                          <div class="radio-subtitle">{{ translate('videoEnhancer.settings.hdSubtitle') }}</div>
                         </div>
                       </el-radio>
                     </label>
                     <label class="radio-option">
                       <el-radio label="4k">
                         <div class="radio-content">
-                          <div class="radio-title">4K</div>
-                          <div class="radio-subtitle">3840×2160</div>
+                          <div class="radio-title">{{ translate('videoEnhancer.settings.fourK') }}</div>
+                          <div class="radio-subtitle">{{ translate('videoEnhancer.settings.fourKSubtitle') }}</div>
                         </div>
                       </el-radio>
                     </label>
@@ -153,12 +163,12 @@
                 class="action-btn btn-process"
                 :disabled="processing || !fileUploaded"
                 @click="startProcessing"
-                :loading="processing"
-              >
-                <span v-if="!processing" class="btn-icon">🚀</span>
-                {{ buttonText }}
+              :loading="processing"
+            >
+              <span v-if="!processing" class="btn-icon">🚀</span>
+                {{ translate(buttonTextKey) }}
               </el-button>
-              
+
               <el-button
                 v-else
                 type="success"
@@ -166,14 +176,14 @@
                 @click="downloadResult"
               >
                 <span class="btn-icon">⬇️</span>
-                Download Enhanced Video
+                {{ translate('videoEnhancer.actions.download') }}
               </el-button>
 
               <!-- 处理进度 -->
               <div v-if="processing" class="process-info">
                 <div class="process-status">
                   <span class="status-icon">⏳</span>
-                  <span class="status-text">Processing your video...</span>
+                  <span class="status-text">{{ translate('videoEnhancer.processing.inProgress') }}</span>
                   <span class="status-percent">{{ processPercent }}%</span>
                 </div>
                 <el-progress
@@ -183,15 +193,15 @@
                   color="#6366f1"
                 />
                 <div class="process-details">
-                  <small>Enhancing quality • Upscaling resolution • Optimizing details</small>
+                  <small>{{ translate('videoEnhancer.processing.details') }}</small>
                 </div>
               </div>
 
               <!-- 完成状态 -->
               <div v-if="processingComplete && !processing" class="process-complete">
                 <div class="complete-icon">✅</div>
-                <div class="complete-text">Enhancement Complete!</div>
-                <div class="complete-subtitle">Your file is ready for download</div>
+                <div class="complete-text">{{ translate('videoEnhancer.processing.completeTitle') }}</div>
+                <div class="complete-subtitle">{{ translate('videoEnhancer.processing.completeSubtitle') }}</div>
               </div>
             </div>
           </div>
@@ -200,7 +210,7 @@
         <!-- 视频对比区域 -->
         <div class="comparison-section">
           <div class="comparison-header">
-            <h2 class="comparison-title">Video Comparison</h2>
+            <h2 class="comparison-title">{{ translate('videoEnhancer.comparison.title') }}</h2>
             <div v-show="showVideoControls" class="comparison-controls">
               <el-button
                 class="control-btn"
@@ -209,7 +219,7 @@
                 round
               >
                 <span class="control-icon">{{ isPlaying ? '⏸️' : '▶️' }}</span>
-                {{ isPlaying ? 'Pause' : 'Play' }}
+                {{ translate(isPlaying ? 'videoEnhancer.comparison.pause' : 'videoEnhancer.comparison.play') }}
               </el-button>
               <el-button
                 class="control-btn"
@@ -218,7 +228,7 @@
                 round
               >
                 <span class="control-icon">🔄</span>
-                Restart
+                {{ translate('videoEnhancer.comparison.restart') }}
               </el-button>
               <el-button
                 class="control-btn"
@@ -227,7 +237,7 @@
                 round
               >
                 <span class="control-icon">{{ isMuted ? '🔇' : '🔊' }}</span>
-                {{ isMuted ? 'Muted' : 'Sound' }}
+                {{ translate(isMuted ? 'videoEnhancer.comparison.muted' : 'videoEnhancer.comparison.sound') }}
               </el-button>
               <el-slider
                 v-model="videoProgress"
@@ -242,7 +252,7 @@
             <!-- 原始视频/图片 -->
             <div class="comparison-item">
               <div class="comparison-label">
-                <span class="label-badge original">Original</span>
+                <span class="label-badge original">{{ translate('videoEnhancer.comparison.original') }}</span>
                 <span class="label-resolution">{{ originalResolution }}</span>
               </div>
               <div
@@ -269,8 +279,8 @@
                 <div v-if="!fileUploaded" class="upload-placeholder">
                   <div class="placeholder-info">
                     <span class="placeholder-icon">📁</span>
-                    <p class="placeholder-text">To be uploaded</p>
-                    <small class="placeholder-hint">Upload a file to begin</small>
+                    <p class="placeholder-text">{{ translate('videoEnhancer.comparison.placeholderTitle') }}</p>
+                    <small class="placeholder-hint">{{ translate('videoEnhancer.comparison.placeholderHint') }}</small>
                   </div>
                 </div>
               </div>
@@ -284,7 +294,7 @@
             <!-- 增强后的视频/图片 -->
             <div class="comparison-item">
               <div class="comparison-label">
-                <span class="label-badge enhanced">Enhanced</span>
+                <span class="label-badge enhanced">{{ translate('videoEnhancer.comparison.enhanced') }}</span>
                 <span class="label-resolution">{{ enhancedResolution }}</span>
               </div>
               <div
@@ -310,8 +320,8 @@
                 <div v-if="!processingComplete || !fileUploaded" class="enhancement-overlay">
                   <div class="enhancement-info">
                     <span class="check-icon">{{ enhancementIcon }}</span>
-                    <p class="enhancement-text">{{ enhancementText }}</p>
-                    <small class="enhancement-hint">{{ enhancementHint }}</small>
+                    <p class="enhancement-text">{{ translate(enhancementTextKey) }}</p>
+                    <small class="enhancement-hint">{{ translate(enhancementHintKey) }}</small>
                   </div>
                 </div>
               </div>
@@ -333,26 +343,30 @@
 </template>
 
 <script>
+import { supportedLocales, translate as translateText } from './i18n'
+
 export default {
   name: 'VideoEnhancer',
   data() {
     return {
+      availableLocales: supportedLocales,
+      locale: 'en-US',
       // 菜单项
       menuItems: [
-        { icon: '📊', label: 'Dashboard', active: false },
-        { icon: '✨', label: 'Video/Image Enhancer', active: true },
-        { icon: '🎨', label: 'Style Transfer', active: false },
-        { icon: '🔊', label: 'Audio Enhancement', active: false },
-        { icon: '📁', label: 'My Projects', active: false },
-        { icon: '⚙️', label: 'Settings', active: false }
+        { icon: '📊', labelKey: 'menu.dashboard', active: false },
+        { icon: '✨', labelKey: 'menu.videoEnhancer', active: true },
+        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
+        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
+        { icon: '📁', labelKey: 'menu.projects', active: false },
+        { icon: '⚙️', labelKey: 'menu.settings', active: false }
       ],
-      
+
       // 示例文件
       samples: [
-        { type: 'portrait', icon: '👤', title: 'Portrait Sample' },
-        { type: 'nature', icon: '🌿', title: 'Nature Sample' },
-        { type: 'cityscape', icon: '🏙️', title: 'Cityscape Sample' },
-        { type: 'food', icon: '🍔', title: 'Food Sample' }
+        { type: 'portrait', icon: '👤', titleKey: 'videoEnhancer.samples.portrait' },
+        { type: 'nature', icon: '🌿', titleKey: 'videoEnhancer.samples.nature' },
+        { type: 'cityscape', icon: '🏙️', titleKey: 'videoEnhancer.samples.cityscape' },
+        { type: 'food', icon: '🍔', titleKey: 'videoEnhancer.samples.food' }
       ],
       
       // 上传状态
@@ -371,7 +385,7 @@ export default {
       processing: false,
       processingComplete: false,
       processPercent: 0,
-      buttonText: 'Apply Enhancement',
+      buttonTextKey: 'videoEnhancer.actions.apply',
       
       // 视频控制
       isPlaying: false,
@@ -397,8 +411,8 @@ export default {
       
       // 增强提示
       enhancementIcon: '📁',
-      enhancementText: 'To be uploaded',
-      enhancementHint: 'Upload a file first'
+      enhancementTextKey: 'videoEnhancer.status.toBeUploaded',
+      enhancementHintKey: 'videoEnhancer.status.uploadHint'
     }
   },
   
@@ -406,13 +420,23 @@ export default {
     // 组件挂载后的初始化
     this.initializeComponent()
   },
-  
+
   beforeDestroy() {
     // 清理资源
     this.cleanup()
   },
-  
+
+  watch: {
+    locale() {
+      this.updateResolutionDisplay()
+    }
+  },
+
   methods: {
+    translate(key) {
+      return translateText(this.locale, key)
+    },
+
     // 初始化组件
     initializeComponent() {
       console.log('Video Enhancer component initialized')
@@ -471,7 +495,7 @@ export default {
     // 处理文件
     handleFiles(files) {
       if (files.length > 8) {
-        this.$message.warning('Maximum 8 files allowed at once')
+        this.$message.warning(this.translate('videoEnhancer.messages.uploadLimit'))
         return
       }
       
@@ -506,9 +530,9 @@ export default {
     showComparisonWithFile() {
       // 更新增强提示
       this.enhancementIcon = '⏳'
-      this.enhancementText = 'To be processed'
-      this.enhancementHint = 'Click Apply to begin'
-      
+      this.enhancementTextKey = 'videoEnhancer.status.toBeProcessed'
+      this.enhancementHintKey = 'videoEnhancer.status.processHint'
+
       // 更新分辨率显示
       this.updateResolutionDisplay()
       
@@ -583,8 +607,8 @@ export default {
       this.originalResolution = '-'
       this.enhancedResolution = '-'
       this.enhancementIcon = '📁'
-      this.enhancementText = 'To be uploaded'
-      this.enhancementHint = 'Upload a file first'
+      this.enhancementTextKey = 'videoEnhancer.status.toBeUploaded'
+      this.enhancementHintKey = 'videoEnhancer.status.uploadHint'
       
       // 清理视频资源
       if (this.originalVideoSrc && this.originalVideoSrc.startsWith('blob:')) {
@@ -605,7 +629,7 @@ export default {
       this.processing = false
       this.processingComplete = false
       this.processPercent = 0
-      this.buttonText = 'Apply Enhancement'
+      this.buttonTextKey = 'videoEnhancer.actions.apply'
     },
     
     // 加载示例
@@ -662,23 +686,27 @@ export default {
     // 更新分辨率显示
     updateResolutionDisplay() {
       if (this.fileUploaded) {
-        this.enhancedResolution = this.resolution === '4k' ? '4K 3840×2160px' : 'HD 1920×1080px'
+        this.enhancedResolution = this.translate(
+          this.resolution === '4k'
+            ? 'videoEnhancer.resolution.fourKLabel'
+            : 'videoEnhancer.resolution.hdLabel'
+        )
       }
     },
-    
+
     // 重置为重新处理状态
     resetToReprocess() {
-      this.buttonText = 'Reprocess Video'
+      this.buttonTextKey = 'videoEnhancer.actions.reprocess'
       this.processingComplete = false
       this.enhancementIcon = '🔄'
-      this.enhancementText = 'Settings changed'
-      this.enhancementHint = 'Click Reprocess to apply new settings'
+      this.enhancementTextKey = 'videoEnhancer.status.settingsChanged'
+      this.enhancementHintKey = 'videoEnhancer.status.settingsHint'
     },
-    
+
     // 开始处理
     startProcessing() {
       if (!this.fileUploaded && !this.filePreview) {
-        this.$message.warning('Please upload a file first')
+        this.$message.warning(this.translate('videoEnhancer.messages.uploadRequired'))
         return
       }
       
@@ -826,7 +854,7 @@ export default {
       link.download = `enhanced_${this.fileName}`
       link.click()
       
-      this.$message.success('Download started')
+      this.$message.success(this.translate('videoEnhancer.messages.downloadStarted'))
     }
   }
 }
@@ -834,4 +862,33 @@ export default {
 
 <style lang="scss" scoped>
 @import './VideoEnhancer.scss';
+
+.language-switcher {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  color: #475569;
+
+  .language-label {
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  .language-select {
+    padding: 6px 12px;
+    border-radius: 8px;
+    border: 1px solid #cbd5f5;
+    background: #f8fafc;
+    color: #334155;
+    font-size: 14px;
+
+    &:focus {
+      outline: none;
+      border-color: #6366f1;
+      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+    }
+  }
+}
 </style>

--- a/WatermarkRemover-PC.scss
+++ b/WatermarkRemover-PC.scss
@@ -143,7 +143,36 @@
   margin-bottom: 30px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
   border: 1px solid rgba(0, 0, 0, 0.05);
-  
+
+  .language-switcher {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+    color: #475569;
+
+    .language-label {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .language-select {
+      padding: 6px 12px;
+      border-radius: 8px;
+      border: 1px solid #cbd5f5;
+      background: #f8fafc;
+      color: #334155;
+      font-size: 14px;
+
+      &:focus {
+        outline: none;
+        border-color: #6366f1;
+        box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+      }
+    }
+  }
+
   .header-title {
     font-size: 36px;
     font-weight: 700;

--- a/WatermarkRemover-PC.vue
+++ b/WatermarkRemover-PC.vue
@@ -2,17 +2,17 @@
   <div class="watermark-remover-page">
     <!-- 侧边栏 -->
     <aside class="sidebar">
-      <div class="logo">MediaEnhance Pro</div>
+      <div class="logo">{{ translate('app.brand') }}</div>
       <nav>
         <ul class="nav-menu">
-          <li 
+          <li
             v-for="(item, index) in menuItems"
             :key="index"
             :class="['nav-item', { active: item.active }]"
             @click="handleMenuClick(index)"
           >
             <span class="nav-icon">{{ item.icon }}</span>
-            <span>{{ item.label }}</span>
+            <span>{{ translate(item.labelKey) }}</span>
           </li>
         </ul>
       </nav>
@@ -20,8 +20,8 @@
         <div class="nav-item user-account">
           <span class="nav-icon">👤</span>
           <div class="user-details">
-            <div class="user-name">User Account</div>
-            <div class="user-plan">Free Plan</div>
+            <div class="user-name">{{ translate('app.user.account') }}</div>
+            <div class="user-plan">{{ translate('app.user.plan') }}</div>
           </div>
         </div>
       </div>
@@ -32,9 +32,19 @@
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
-          <h1 class="header-title">Watermark & Text Remover</h1>
+          <div class="language-switcher">
+            <label :for="`${$options.name}-locale`" class="language-label">
+              {{ translate('language.label') }}
+            </label>
+            <select :id="`${$options.name}-locale`" v-model="locale" class="language-select">
+              <option v-for="code in availableLocales" :key="code" :value="code">
+                {{ translate(`language.options.${code}`) }}
+              </option>
+            </select>
+          </div>
+          <h1 class="header-title">{{ translate('watermark.header.title') }}</h1>
           <p class="header-subtitle">
-            Remove unwanted watermarks, logos, text, and objects from your images and videos using advanced AI-powered content-aware fill technology.
+            {{ translate('watermark.header.subtitle') }}
           </p>
         </div>
 
@@ -44,7 +54,7 @@
           <div class="workspace-left">
             <!-- 上传区域 -->
             <div class="upload-container">
-              <div class="section-title">Upload Media</div>
+              <div class="section-title">{{ translate('watermark.upload.title') }}</div>
               <div
                 :class="['upload-area', { 'has-file': hasFile, 'dragover': isDragover }]"
                 @drop.prevent="handleDrop"
@@ -53,19 +63,19 @@
                 @click="!hasFile && triggerFileInput()"
               >
                 <div v-if="uploadSuccess" class="upload-success-badge">✔</div>
-                
+
                 <!-- 上传内容 -->
                 <div v-if="!filePreview" class="upload-content">
                   <div class="upload-icon">⬆️</div>
-                  <div class="upload-title">Drop your files here</div>
-                  <div class="upload-subtitle">or click to browse</div>
+                  <div class="upload-title">{{ translate('watermark.upload.drop') }}</div>
+                  <div class="upload-subtitle">{{ translate('watermark.upload.browse') }}</div>
                   <el-button type="primary" class="upload-btn-small" @click.stop="triggerFileInput">
-                    Choose Files
+                    {{ translate('watermark.upload.button') }}
                   </el-button>
-                  <input 
+                  <input
                     ref="fileInput"
-                    type="file" 
-                    class="file-input" 
+                    type="file"
+                    class="file-input"
                     multiple 
                     accept=".mp4,.mov,.m4v,.3gp,.avi,.jpg,.jpeg,.png" 
                     @change="handleFileSelect"
@@ -95,20 +105,20 @@
                 </div>
               </div>
               <div class="supported-formats">
-                Supported: .mp4, .mov, .m4v, .3gp, .avi, .jpg, .jpeg, .png (Max 100MB)
+                {{ translate('watermark.upload.supported') }}
               </div>
             </div>
 
             <!-- 示例文件 -->
             <div class="samples-container">
-              <div class="section-title">Quick Samples</div>
+              <div class="section-title">{{ translate('watermark.samples.title') }}</div>
               <div class="sample-grid">
                 <div
                   v-for="sample in samples"
                   :key="sample.type"
                   class="sample-item"
                   @click="loadSample(sample.type)"
-                  :title="sample.title"
+                  :title="translate(sample.titleKey)"
                 >
                   <span class="sample-icon">{{ sample.icon }}</span>
                 </div>
@@ -120,7 +130,7 @@
           <div class="workspace-right">
             <!-- 移除模式设置 -->
             <div class="settings-container">
-              <div class="section-title">Removal Mode</div>
+              <div class="section-title">{{ translate('watermark.settings.title') }}</div>
               
               <!-- 移除模式选择 -->
               <div class="setting-group">
@@ -133,7 +143,7 @@
                   >
                     <div class="mode-content">
                       <span class="mode-icon">{{ mode.icon }}</span>
-                      <span class="mode-title">{{ mode.label }}</span>
+                      <span class="mode-title">{{ translate(mode.labelKey) }}</span>
                     </div>
                   </el-radio>
                 </el-radio-group>
@@ -151,7 +161,7 @@
                 :loading="processing"
               >
                 <span v-if="!processing" class="btn-icon">🧹</span>
-                <span>{{ buttonText }}</span>
+                <span>{{ translate(buttonTextKey) }}</span>
               </el-button>
               
               <el-button
@@ -161,14 +171,14 @@
                 @click="downloadResult"
               >
                 <span class="btn-icon">⬇️</span>
-                Download Clean Media
+                {{ translate('watermark.actions.download') }}
               </el-button>
 
               <!-- 处理进度 -->
               <div v-if="processing" class="process-info">
                 <div class="process-status">
                   <span class="status-icon">⏳</span>
-                  <span class="status-text">Processing your media...</span>
+                  <span class="status-text">{{ translate('watermark.processing.inProgress') }}</span>
                   <span class="status-percent">{{ processPercent }}%</span>
                 </div>
                 <el-progress
@@ -178,15 +188,15 @@
                   class="progress-bar"
                 />
                 <div class="process-details">
-                  <small>Detecting watermarks • Analyzing content • Applying smart fill</small>
+                  <small>{{ translate('watermark.processing.details') }}</small>
                 </div>
               </div>
 
               <!-- 完成状态 -->
               <div v-if="processingComplete && !processing" class="process-complete">
                 <span class="complete-icon">✅</span>
-                <div class="complete-text">Watermark Removed Successfully!</div>
-                <div class="complete-subtitle">Your clean media is ready for download</div>
+                <div class="complete-text">{{ translate('watermark.processing.completeTitle') }}</div>
+                <div class="complete-subtitle">{{ translate('watermark.processing.completeSubtitle') }}</div>
               </div>
             </div>
           </div>
@@ -195,15 +205,15 @@
         <!-- 结果对比区域 -->
         <div class="comparison-section">
           <div class="comparison-header">
-            <h2 class="comparison-title">Result Comparison</h2>
+            <h2 class="comparison-title">{{ translate('watermark.comparison.title') }}</h2>
           </div>
-          
+
           <div class="comparison-container">
             <!-- 原始图片/视频 -->
             <div class="comparison-item">
               <div class="comparison-label">
-                <span class="label-badge original">Original</span>
-                <span class="label-info">{{ originalInfo }}</span>
+                <span class="label-badge original">{{ translate('watermark.comparison.original') }}</span>
+                <span class="label-info">{{ translate(originalInfoKey) }}</span>
               </div>
               <div class="image-wrapper">
                 <img
@@ -222,8 +232,8 @@
                 <div v-if="!fileUploaded" class="upload-placeholder">
                   <div class="placeholder-info">
                     <span class="placeholder-icon">📂</span>
-                    <p>To be uploaded</p>
-                    <small>Upload a file to begin</small>
+                    <p>{{ translate('watermark.comparison.placeholderTitle') }}</p>
+                    <small>{{ translate('watermark.comparison.placeholderHint') }}</small>
                   </div>
                 </div>
               </div>
@@ -237,8 +247,8 @@
             <!-- 清理后的图片/视频 -->
             <div class="comparison-item">
               <div class="comparison-label">
-                <span class="label-badge cleaned">Cleaned</span>
-                <span class="label-info">{{ cleanedInfo }}</span>
+                <span class="label-badge cleaned">{{ translate('watermark.comparison.cleaned') }}</span>
+                <span class="label-info">{{ translate(cleanedInfoKey) }}</span>
               </div>
               <div class="image-wrapper">
                 <img
@@ -257,8 +267,8 @@
                 <div v-if="!processingComplete || !fileUploaded" class="process-placeholder">
                   <div class="placeholder-info">
                     <span class="placeholder-icon">{{ placeholderIcon }}</span>
-                    <p>{{ placeholderText }}</p>
-                    <small>{{ placeholderHint }}</small>
+                    <p>{{ translate(placeholderTextKey) }}</p>
+                    <small>{{ translate(placeholderHintKey) }}</small>
                   </div>
                 </div>
               </div>
@@ -271,34 +281,39 @@
 </template>
 
 <script>
+import { supportedLocales, translate as translateText } from './i18n'
+
 export default {
   name: 'WatermarkRemover',
   data() {
     return {
+      availableLocales: supportedLocales,
+      locale: 'en-US',
+
       // Menu items
       menuItems: [
-        { icon: '📊', label: 'Dashboard', active: false },
-        { icon: '✨', label: 'Video/Image Enhancer', active: false },
-        { icon: '🧹', label: 'Watermark Remover', active: true },
-        { icon: '🎨', label: 'Style Transfer', active: false },
-        { icon: '🔊', label: 'Audio Enhancement', active: false },
-        { icon: '📁', label: 'My Projects', active: false },
-        { icon: '⚙️', label: 'Settings', active: false }
+        { icon: '📊', labelKey: 'menu.dashboard', active: false },
+        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
+        { icon: '🧹', labelKey: 'menu.watermarkRemover', active: true },
+        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
+        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
+        { icon: '📁', labelKey: 'menu.projects', active: false },
+        { icon: '⚙️', labelKey: 'menu.settings', active: false }
       ],
-      
+
       // Sample files
       samples: [
-        { type: 'watermark', icon: '💧', title: 'Watermark Sample' },
-        { type: 'logo', icon: '🏷️', title: 'Logo Sample' },
-        { type: 'text', icon: '📝', title: 'Text Sample' },
-        { type: 'object', icon: '🗑️', title: 'Object Sample' }
+        { type: 'watermark', icon: '💧', titleKey: 'watermark.samples.watermark' },
+        { type: 'logo', icon: '🏷️', titleKey: 'watermark.samples.logo' },
+        { type: 'text', icon: '📝', titleKey: 'watermark.samples.text' },
+        { type: 'object', icon: '🗑️', titleKey: 'watermark.samples.object' }
       ],
-      
+
       // Removal modes
       removalModes: [
-        { value: 'smart', label: 'Smart Remove', icon: '✨' },
-        { value: 'watermark', label: 'Remove Watermark', icon: '💧' },
-        { value: 'subtitle', label: 'Remove Subtitle', icon: '📝' }
+        { value: 'smart', labelKey: 'watermark.settings.modes.smart', icon: '✨' },
+        { value: 'watermark', labelKey: 'watermark.settings.modes.watermark', icon: '💧' },
+        { value: 'subtitle', labelKey: 'watermark.settings.modes.subtitle', icon: '📝' }
       ],
       
       // Upload state
@@ -317,7 +332,7 @@ export default {
       processing: false,
       processingComplete: false,
       processPercent: 0,
-      buttonText: 'Remove Watermark',
+      buttonTextKey: 'watermark.actions.remove',
       
       // Display state
       showOriginalVideo: false,
@@ -330,17 +345,21 @@ export default {
       cleanedImageSrc: '',
       
       // Info text
-      originalInfo: 'With Watermark',
-      cleanedInfo: 'Watermark Removed',
-      
+      originalInfoKey: 'watermark.status.withWatermark',
+      cleanedInfoKey: 'watermark.status.removed',
+
       // Placeholder state
       placeholderIcon: '⏳',
-      placeholderText: 'To be processed',
-      placeholderHint: 'Upload a file first'
+      placeholderTextKey: 'watermark.status.toBeProcessed',
+      placeholderHintKey: 'watermark.status.uploadHint'
     }
   },
-  
+
   methods: {
+    translate(key) {
+      return translateText(this.locale, key)
+    },
+
     // Handle menu click
     handleMenuClick(index) {
       this.menuItems.forEach((item, i) => {
@@ -384,7 +403,7 @@ export default {
       if (files.length > 0) {
         // Check file size
         if (files[0].size > 100 * 1024 * 1024) {
-          this.$message.error('File size exceeds 100MB limit')
+          this.$message.error(this.translate('watermark.messages.fileTooLarge'))
           return
         }
         
@@ -420,12 +439,12 @@ export default {
     showComparisonWithFile() {
       // Update placeholder
       this.placeholderIcon = '⏳'
-      this.placeholderText = 'Ready to process'
-      this.placeholderHint = 'Click Remove Watermark to begin'
-      
+      this.placeholderTextKey = 'watermark.status.ready'
+      this.placeholderHintKey = 'watermark.status.processHint'
+
       // Update info text
-      this.originalInfo = 'With Watermark'
-      this.cleanedInfo = 'Ready to process'
+      this.originalInfoKey = 'watermark.status.withWatermark'
+      this.cleanedInfoKey = 'watermark.status.ready'
       
       // Setup original content
       if (this.fileType === 'video') {
@@ -470,19 +489,19 @@ export default {
       this.showOriginalImage = false
       this.showCleanedVideo = false
       this.showCleanedImage = false
-      this.originalInfo = 'With Watermark'
-      this.cleanedInfo = 'Watermark Removed'
+      this.originalInfoKey = 'watermark.status.withWatermark'
+      this.cleanedInfoKey = 'watermark.status.removed'
       this.placeholderIcon = '⏳'
-      this.placeholderText = 'To be processed'
-      this.placeholderHint = 'Upload a file first'
+      this.placeholderTextKey = 'watermark.status.toBeProcessed'
+      this.placeholderHintKey = 'watermark.status.uploadHint'
     },
-    
+
     // Reset processing state
     resetProcessingState() {
       this.processing = false
       this.processingComplete = false
       this.processPercent = 0
-      this.buttonText = 'Remove Watermark'
+      this.buttonTextKey = 'watermark.actions.remove'
     },
     
     // Load sample
@@ -582,17 +601,17 @@ export default {
     
     // Reset to reprocess state
     resetToReprocess() {
-      this.buttonText = 'Reprocess Media'
+      this.buttonTextKey = 'watermark.actions.reprocess'
       this.processingComplete = false
       this.placeholderIcon = '🔄'
-      this.placeholderText = 'Mode changed'
-      this.placeholderHint = 'Click Reprocess to apply new mode'
+      this.placeholderTextKey = 'watermark.status.modeChanged'
+      this.placeholderHintKey = 'watermark.status.reprocessHint'
     },
     
     // Start processing
     startProcessing() {
       if (!this.hasFile) {
-        this.$message.warning('Please upload a file first')
+        this.$message.warning(this.translate('watermark.messages.uploadRequired'))
         return
       }
       
@@ -610,7 +629,7 @@ export default {
             this.processing = false
             this.processingComplete = true
             this.showCleanedResult()
-            this.$message.success('Watermark removed successfully!')
+            this.$message.success(this.translate('watermark.messages.success'))
           }, 500)
         }
       }, 200)
@@ -619,12 +638,12 @@ export default {
     // Show cleaned result
     showCleanedResult() {
       const modeText = {
-        'smart': 'Smart Remove',
-        'watermark': 'Watermark Removed',
-        'subtitle': 'Subtitle Removed'
+        smart: 'watermark.settings.modes.smart',
+        watermark: 'watermark.status.removed',
+        subtitle: 'watermark.status.subtitleRemoved'
       }
-      this.cleanedInfo = modeText[this.removalMode] || 'Processed'
-      
+      this.cleanedInfoKey = modeText[this.removalMode] || 'watermark.status.processed'
+
       if (this.fileType === 'video') {
         this.setupCleanedVideo()
       } else {
@@ -648,7 +667,7 @@ export default {
     
     // Download result
     downloadResult() {
-      this.$message.info('Downloading clean media...')
+      this.$message.info(this.translate('watermark.messages.download'))
       
       // Create download link
       const link = document.createElement('a')

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,35 @@
+import enUS from './locales/en-US.json'
+import zhCN from './locales/zh-CN.json'
+
+export const supportedLocales = ['en-US', 'zh-CN']
+
+export const messages = {
+  'en-US': enUS,
+  'zh-CN': zhCN
+}
+
+export function translate(locale, key) {
+  const targetLocale = supportedLocales.includes(locale) ? locale : 'en-US'
+  const segments = key.split('.')
+  let current = messages[targetLocale]
+
+  for (const segment of segments) {
+    if (current && Object.prototype.hasOwnProperty.call(current, segment)) {
+      current = current[segment]
+    } else {
+      current = null
+      break
+    }
+  }
+
+  if (typeof current === 'string') {
+    return current
+  }
+
+  // 尝试使用英文作为回退
+  if (targetLocale !== 'en-US') {
+    return translate('en-US', key)
+  }
+
+  return key
+}

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1,0 +1,157 @@
+{
+  "language": {
+    "label": "Language",
+    "options": {
+      "en-US": "English",
+      "zh-CN": "中文"
+    }
+  },
+  "app": {
+    "brand": "MediaEnhance Pro",
+    "user": {
+      "account": "User Account",
+      "plan": "Free Plan"
+    }
+  },
+  "menu": {
+    "dashboard": "Dashboard",
+    "videoEnhancer": "Video/Image Enhancer",
+    "watermarkRemover": "Watermark Remover",
+    "styleTransfer": "Style Transfer",
+    "audioEnhancement": "Audio Enhancement",
+    "projects": "My Projects",
+    "settings": "Settings"
+  },
+  "videoEnhancer": {
+    "header": {
+      "title": "Video & Image Enhancer",
+      "subtitle": "Transform your low-quality videos and images into stunning high-resolution masterpieces using advanced AI technology."
+    },
+    "upload": {
+      "title": "Upload Media",
+      "drop": "Drop your files here",
+      "browse": "or click to browse",
+      "button": "Choose Files",
+      "supported": "Supported: .mp4, .mov, .m4v, .3gp, .avi, .jpg, .jpeg, .png (Max 8 files)"
+    },
+    "samples": {
+      "title": "Quick Samples",
+      "portrait": "Portrait Sample",
+      "nature": "Nature Sample",
+      "cityscape": "Cityscape Sample",
+      "food": "Food Sample"
+    },
+    "settings": {
+      "title": "Enhancement Settings",
+      "resolution": "Output Resolution",
+      "hd": "HD",
+      "hdSubtitle": "1920×1080",
+      "fourK": "4K",
+      "fourKSubtitle": "3840×2160"
+    },
+    "actions": {
+      "apply": "Apply Enhancement",
+      "reprocess": "Reprocess Video",
+      "download": "Download Enhanced Video"
+    },
+    "processing": {
+      "inProgress": "Processing your video...",
+      "details": "Enhancing quality • Upscaling resolution • Optimizing details",
+      "completeTitle": "Enhancement Complete!",
+      "completeSubtitle": "Your file is ready for download"
+    },
+    "comparison": {
+      "title": "Video Comparison",
+      "original": "Original",
+      "enhanced": "Enhanced",
+      "play": "Play",
+      "pause": "Pause",
+      "restart": "Restart",
+      "muted": "Muted",
+      "sound": "Sound",
+      "placeholderTitle": "To be uploaded",
+      "placeholderHint": "Upload a file to begin"
+    },
+    "status": {
+      "toBeUploaded": "To be uploaded",
+      "uploadHint": "Upload a file first",
+      "toBeProcessed": "To be processed",
+      "processHint": "Click Apply to begin",
+      "settingsChanged": "Settings changed",
+      "settingsHint": "Click Reprocess to apply new settings"
+    },
+    "resolution": {
+      "hdLabel": "HD 1920×1080px",
+      "fourKLabel": "4K 3840×2160px"
+    },
+    "messages": {
+      "uploadLimit": "Maximum 8 files allowed at once",
+      "uploadRequired": "Please upload a file first",
+      "downloadStarted": "Download started"
+    }
+  },
+  "watermark": {
+    "header": {
+      "title": "Watermark & Text Remover",
+      "subtitle": "Remove unwanted watermarks, logos, text, and objects from your images and videos using advanced AI-powered content-aware fill technology."
+    },
+    "upload": {
+      "title": "Upload Media",
+      "drop": "Drop your files here",
+      "browse": "or click to browse",
+      "button": "Choose Files",
+      "supported": "Supported: .mp4, .mov, .m4v, .3gp, .avi, .jpg, .jpeg, .png (Max 100MB)"
+    },
+    "samples": {
+      "title": "Quick Samples",
+      "watermark": "Watermark Sample",
+      "logo": "Logo Sample",
+      "text": "Text Sample",
+      "object": "Object Sample"
+    },
+    "settings": {
+      "title": "Removal Mode",
+      "modes": {
+        "smart": "Smart Remove",
+        "watermark": "Remove Watermark",
+        "subtitle": "Remove Subtitle"
+      }
+    },
+    "actions": {
+      "remove": "Remove Watermark",
+      "reprocess": "Reprocess Media",
+      "download": "Download Clean Media"
+    },
+    "processing": {
+      "inProgress": "Processing your media...",
+      "details": "Detecting watermarks • Analyzing content • Applying smart fill",
+      "completeTitle": "Watermark Removed Successfully!",
+      "completeSubtitle": "Your clean media is ready for download"
+    },
+    "comparison": {
+      "title": "Result Comparison",
+      "original": "Original",
+      "cleaned": "Cleaned",
+      "placeholderTitle": "To be uploaded",
+      "placeholderHint": "Upload a file to begin"
+    },
+    "status": {
+      "withWatermark": "With Watermark",
+      "removed": "Watermark Removed",
+      "subtitleRemoved": "Subtitle Removed",
+      "toBeProcessed": "To be processed",
+      "ready": "Ready to process",
+      "modeChanged": "Mode changed",
+      "processed": "Processed",
+      "uploadHint": "Upload a file first",
+      "processHint": "Click Remove Watermark to begin",
+      "reprocessHint": "Click Reprocess to apply new mode"
+    },
+    "messages": {
+      "fileTooLarge": "File size exceeds 100MB limit",
+      "uploadRequired": "Please upload a file first",
+      "success": "Watermark removed successfully!",
+      "download": "Downloading clean media..."
+    }
+  }
+}

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -1,0 +1,157 @@
+{
+  "language": {
+    "label": "语言",
+    "options": {
+      "en-US": "English",
+      "zh-CN": "中文"
+    }
+  },
+  "app": {
+    "brand": "MediaEnhance Pro",
+    "user": {
+      "account": "用户账号",
+      "plan": "免费版"
+    }
+  },
+  "menu": {
+    "dashboard": "数据概览",
+    "videoEnhancer": "视频/图像增强",
+    "watermarkRemover": "水印去除",
+    "styleTransfer": "风格迁移",
+    "audioEnhancement": "音频增强",
+    "projects": "我的项目",
+    "settings": "设置"
+  },
+  "videoEnhancer": {
+    "header": {
+      "title": "视频与图像增强",
+      "subtitle": "利用先进的人工智能技术，将低清晰度的视频和图片转化为高分辨率的惊艳作品。"
+    },
+    "upload": {
+      "title": "上传素材",
+      "drop": "将文件拖拽到此处",
+      "browse": "或点击浏览",
+      "button": "选择文件",
+      "supported": "支持格式：.mp4、.mov、.m4v、.3gp、.avi、.jpg、.jpeg、.png（最多 8 个文件）"
+    },
+    "samples": {
+      "title": "快速示例",
+      "portrait": "人像示例",
+      "nature": "自然示例",
+      "cityscape": "城市示例",
+      "food": "美食示例"
+    },
+    "settings": {
+      "title": "增强设置",
+      "resolution": "输出分辨率",
+      "hd": "高清",
+      "hdSubtitle": "1920×1080",
+      "fourK": "4K",
+      "fourKSubtitle": "3840×2160"
+    },
+    "actions": {
+      "apply": "开始增强",
+      "reprocess": "重新增强",
+      "download": "下载增强结果"
+    },
+    "processing": {
+      "inProgress": "正在处理中...",
+      "details": "质量增强 • 分辨率提升 • 细节优化",
+      "completeTitle": "增强完成！",
+      "completeSubtitle": "文件已准备好，可立即下载"
+    },
+    "comparison": {
+      "title": "效果对比",
+      "original": "原始素材",
+      "enhanced": "增强结果",
+      "play": "播放",
+      "pause": "暂停",
+      "restart": "重新开始",
+      "muted": "静音",
+      "sound": "声音",
+      "placeholderTitle": "等待上传",
+      "placeholderHint": "上传文件即可开始"
+    },
+    "status": {
+      "toBeUploaded": "等待上传",
+      "uploadHint": "请先上传文件",
+      "toBeProcessed": "准备处理",
+      "processHint": "点击开始增强",
+      "settingsChanged": "设置已更改",
+      "settingsHint": "点击重新增强以应用新设置"
+    },
+    "resolution": {
+      "hdLabel": "高清 1920×1080 像素",
+      "fourKLabel": "4K 3840×2160 像素"
+    },
+    "messages": {
+      "uploadLimit": "一次最多只能上传 8 个文件",
+      "uploadRequired": "请先上传文件",
+      "downloadStarted": "开始下载"
+    }
+  },
+  "watermark": {
+    "header": {
+      "title": "水印与文字去除",
+      "subtitle": "基于 AI 的内容感知填充技术，轻松移除图片或视频中的水印、标志、字幕和杂物。"
+    },
+    "upload": {
+      "title": "上传素材",
+      "drop": "将文件拖拽到此处",
+      "browse": "或点击浏览",
+      "button": "选择文件",
+      "supported": "支持格式：.mp4、.mov、.m4v、.3gp、.avi、.jpg、.jpeg、.png（最大 100MB）"
+    },
+    "samples": {
+      "title": "快速示例",
+      "watermark": "水印示例",
+      "logo": "标志示例",
+      "text": "文字示例",
+      "object": "物体示例"
+    },
+    "settings": {
+      "title": "去除模式",
+      "modes": {
+        "smart": "智能去除",
+        "watermark": "移除水印",
+        "subtitle": "移除字幕"
+      }
+    },
+    "actions": {
+      "remove": "开始去除",
+      "reprocess": "重新处理",
+      "download": "下载净化结果"
+    },
+    "processing": {
+      "inProgress": "正在处理中...",
+      "details": "检测水印 • 分析内容 • 智能填充",
+      "completeTitle": "水印去除成功！",
+      "completeSubtitle": "净化后的文件已准备就绪"
+    },
+    "comparison": {
+      "title": "结果对比",
+      "original": "原始素材",
+      "cleaned": "净化结果",
+      "placeholderTitle": "等待上传",
+      "placeholderHint": "上传文件即可开始"
+    },
+    "status": {
+      "withWatermark": "原始带水印",
+      "removed": "水印已去除",
+      "subtitleRemoved": "字幕已去除",
+      "toBeProcessed": "等待处理",
+      "ready": "准备处理",
+      "modeChanged": "模式已调整",
+      "processed": "处理完成",
+      "uploadHint": "请先上传文件",
+      "processHint": "点击开始去除",
+      "reprocessHint": "点击重新处理以应用新模式"
+    },
+    "messages": {
+      "fileTooLarge": "文件大小超过 100MB 限制",
+      "uploadRequired": "请先上传文件",
+      "success": "水印去除成功！",
+      "download": "正在下载净化后的文件..."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight i18n helper and English/Chinese locale dictionaries for reuse across the PC views
- internationalize the Video Enhancer interface with a language selector, translation keys, and localized messaging
- localize the Watermark Remover UI and styles, wiring all user-facing text through the shared translations

## Testing
- npm test *(fails: repository has no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdf65b8a8832ebd63e26d8b946f42